### PR TITLE
Add flag to not sort output

### DIFF
--- a/cmd/perforator/flags.go
+++ b/cmd/perforator/flags.go
@@ -18,6 +18,7 @@ var opts struct {
 	Summary     bool     `short:"s" long:"summary" description:"Instead of printing results immediately, show an aggregated summary afterwards"`
 	SortKey     string   `long:"sort-key" description:"Key to sort summary tables with"`
 	ReverseSort bool     `long:"reverse-sort" description:"Reverse summary table sorting"`
+	NoSort      bool     `long:"no-sort" description:"Don't sort the summary table"`
 	Csv         bool     `long:"csv" description:"Write summary output in CSV format"`
 	Output      string   `short:"o" long:"output" description:"Write summary output to file"`
 	Verbose     bool     `short:"V" long:"verbose" description:"Show verbose debug information"`

--- a/cmd/perforator/perforator.go
+++ b/cmd/perforator/perforator.go
@@ -138,7 +138,11 @@ func main() {
 		}
 
 		mv := metricsWriter(out)
-		total.WriteTo(mv, opts.SortKey, opts.ReverseSort)
+		if opts.NoSort {
+			total.WriteTo(mv)
+		} else {
+			total.WriteToSorted(mv, opts.SortKey, opts.ReverseSort)
+		}
 		out.Close()
 	}
 }

--- a/man/perforator.md
+++ b/man/perforator.md
@@ -117,6 +117,10 @@ _trace_
 
 :    Reverse summary table sorting.
 
+  `--no-sort`
+
+:    Don't sort the summary table.
+
   `--csv`
 
 :    Write summary output in CSV format.
@@ -149,4 +153,3 @@ Zachary Yedidia <zyedidia@gmail.com>
 # SEE ALSO
 
 **perf(1)**, **perf\_event\_open(2)**
-


### PR DESCRIPTION
I've added a flag, `--no-sort`, which will disable the sorting of the summary table.

I opted for the inverse (a flag to disable something) as it's non-breaking.