### PR TITLE
Add a flag to ignore missing regions

### DIFF
--- a/cmd/perforator/flags.go
+++ b/cmd/perforator/flags.go
@@ -8,22 +8,23 @@ import (
 )
 
 var opts struct {
-	List        string   `short:"l" long:"list" description:"List available events for {hardware, software, cache, trace} event types"`
-	Events      string   `short:"e" long:"events" default-mask:"-" default:"instructions,branch-instructions,branch-misses,cache-references,cache-misses" description:"Comma-separated list of events to profile"`
-	GroupEvents []string `short:"g" long:"group" description:"Comma-separated list of events to profile together as a group"`
-	Regions     []string `short:"r" long:"region" description:"Region(s) to profile: 'function' or 'start-end'; start/end locations may be file:line or hex addresses"`
-	Kernel      bool     `long:"kernel" description:"Include kernel code in measurements"`
-	Hypervisor  bool     `long:"hypervisor" description:"Include hypervisor code in measurements"`
-	ExcludeUser bool     `long:"exclude-user" description:"Exclude user code from measurements"`
-	Summary     bool     `short:"s" long:"summary" description:"Instead of printing results immediately, show an aggregated summary afterwards"`
-	SortKey     string   `long:"sort-key" description:"Key to sort summary tables with"`
-	ReverseSort bool     `long:"reverse-sort" description:"Reverse summary table sorting"`
-	NoSort      bool     `long:"no-sort" description:"Don't sort the summary table"`
-	Csv         bool     `long:"csv" description:"Write summary output in CSV format"`
-	Output      string   `short:"o" long:"output" description:"Write summary output to file"`
-	Verbose     bool     `short:"V" long:"verbose" description:"Show verbose debug information"`
-	Version     bool     `short:"v" long:"version" description:"Show version information"`
-	Help        bool     `short:"h" long:"help" description:"Show this help message"`
+	List                 string   `short:"l" long:"list" description:"List available events for {hardware, software, cache, trace} event types"`
+	Events               string   `short:"e" long:"events" default-mask:"-" default:"instructions,branch-instructions,branch-misses,cache-references,cache-misses" description:"Comma-separated list of events to profile"`
+	GroupEvents          []string `short:"g" long:"group" description:"Comma-separated list of events to profile together as a group"`
+	Regions              []string `short:"r" long:"region" description:"Region(s) to profile: 'function' or 'start-end'; start/end locations may be file:line or hex addresses"`
+	Kernel               bool     `long:"kernel" description:"Include kernel code in measurements"`
+	Hypervisor           bool     `long:"hypervisor" description:"Include hypervisor code in measurements"`
+	ExcludeUser          bool     `long:"exclude-user" description:"Exclude user code from measurements"`
+	Summary              bool     `short:"s" long:"summary" description:"Instead of printing results immediately, show an aggregated summary afterwards"`
+	SortKey              string   `long:"sort-key" description:"Key to sort summary tables with"`
+	ReverseSort          bool     `long:"reverse-sort" description:"Reverse summary table sorting"`
+	NoSort               bool     `long:"no-sort" description:"Don't sort the summary table"`
+	Csv                  bool     `long:"csv" description:"Write summary output in CSV format"`
+	Output               string   `short:"o" long:"output" description:"Write summary output to file"`
+	Verbose              bool     `short:"V" long:"verbose" description:"Show verbose debug information"`
+	Version              bool     `short:"v" long:"version" description:"Show version information"`
+	Help                 bool     `short:"h" long:"help" description:"Show this help message"`
+	IgnoreMissingRegions bool     `long:"ignore-missing-regions" description:"Continues execution even if a region is missing"`
 }
 
 // ParseEventList looks at a comma-separated list of events and returns the

--- a/cmd/perforator/perforator.go
+++ b/cmd/perforator/perforator.go
@@ -121,7 +121,7 @@ func main() {
 		return metricsWriter(out)
 	}
 
-	total, err := perforator.Run(target, args, opts.Regions, evs, perfOpts, immediate)
+	total, err := perforator.Run(target, args, opts.Regions, evs, perfOpts, immediate, opts.IgnoreMissingRegions)
 	if err != nil {
 		fatal(err)
 	}

--- a/man/perforator.md
+++ b/man/perforator.md
@@ -141,6 +141,9 @@ _trace_
 
 :    Show this help message.
 
+  `--ignore-missing-regions`
+
+:    Continues execution even if a region is missing.
 
 # BUGS
 

--- a/perforator.go
+++ b/perforator.go
@@ -26,7 +26,8 @@ func Run(target string, args []string,
 	regionNames []string,
 	events Events,
 	attropts perf.Options,
-	immediate func() MetricsWriter) (TotalMetrics, error) {
+	immediate func() MetricsWriter,
+	ignoreMissingRegions bool) (TotalMetrics, error) {
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -82,7 +83,7 @@ func Run(target string, args []string,
 
 			if err != nil {
 				if fnerr != nil {
-					if err != nil {
+					if err != nil && !ignoreMissingRegions {
 						return TotalMetrics{}, fmt.Errorf("func-lookup: %w, inlined-func-lookup: %s", fnerr, err)
 					}
 				}


### PR DESCRIPTION
I've added a flag, `--ignore-missing-regions`, which will allow perforator to continue running even though it's unable to find a region.

The change is non-breaking.

The use case is times where you compare a non-optimized reference implementation with an optimized (`-O3` or the like) implementation. In the latter case, GCC and friends may happily inline functions that are only used a single time. This results in the binary (symbol table) not containing the symbol at all - since it's no longer a function per say.

With this change, one may use `--ignore-missing-regions` to run both binaries with the same perforator command, making it more useful in scripts where it may be unknown if the target binary lacks a specific region.