### PR TITLE
Support custom range inner delimiter & demangled function names

### DIFF
--- a/cmd/perforator/flags.go
+++ b/cmd/perforator/flags.go
@@ -26,6 +26,7 @@ var opts struct {
 	Version              bool     `short:"v" long:"version" description:"Show version information"`
 	Help                 bool     `short:"h" long:"help" description:"Show this help message"`
 	RangeInnerDelimiter  string   `long:"range-inner-delim" default:"-" description:"Set range inner delimiter"`
+	ExcludeClones        bool     `long:"exclude-clones" description:"Exclude clone functions in case of range is a function name"`
 }
 
 // ParseEventList looks at a comma-separated list of events and returns the

--- a/cmd/perforator/flags.go
+++ b/cmd/perforator/flags.go
@@ -25,6 +25,7 @@ var opts struct {
 	Verbose              bool     `short:"V" long:"verbose" description:"Show verbose debug information"`
 	Version              bool     `short:"v" long:"version" description:"Show version information"`
 	Help                 bool     `short:"h" long:"help" description:"Show this help message"`
+	RangeInnerDelimiter  string   `long:"range-inner-delim" default:"-" description:"Set range inner delimiter"`
 }
 
 // ParseEventList looks at a comma-separated list of events and returns the

--- a/cmd/perforator/perforator.go
+++ b/cmd/perforator/perforator.go
@@ -121,7 +121,7 @@ func main() {
 		return metricsWriter(out)
 	}
 
-	total, err := perforator.Run(target, args, opts.Regions, evs, perfOpts, immediate, opts.IgnoreMissingRegions)
+	total, err := perforator.Run(target, args, opts.Regions, evs, perfOpts, immediate, opts.IgnoreMissingRegions, opts.RangeInnerDelimiter)
 	if err != nil {
 		fatal(err)
 	}

--- a/cmd/perforator/perforator.go
+++ b/cmd/perforator/perforator.go
@@ -121,7 +121,7 @@ func main() {
 		return metricsWriter(out)
 	}
 
-	total, err := perforator.Run(target, args, opts.Regions, evs, perfOpts, immediate, opts.IgnoreMissingRegions, opts.RangeInnerDelimiter)
+	total, err := perforator.Run(target, args, opts.Regions, evs, perfOpts, immediate, opts.IgnoreMissingRegions, opts.RangeInnerDelimiter, opts.ExcludeClones)
 	if err != nil {
 		fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/ianlancetaylor/demangle v0.0.0-20231023195312-e2daf7ba7156
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/zyedidia/perf v0.0.0-20210820191656-a7f405836330 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/ianlancetaylor/demangle v0.0.0-20231023195312-e2daf7ba7156 h1:XaXfcSUnkTV/iujizC1//N5IrJA1v6KQHwMDbsZesoM=
+github.com/ianlancetaylor/demangle v0.0.0-20231023195312-e2daf7ba7156/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=

--- a/perforator.go
+++ b/perforator.go
@@ -28,7 +28,8 @@ func Run(target string, args []string,
 	attropts perf.Options,
 	immediate func() MetricsWriter,
 	ignoreMissingRegions bool,
-	rangeInnerDelimiter string) (TotalMetrics, error) {
+	rangeInnerDelimiter string,
+	excludeClones bool) (TotalMetrics, error) {
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -67,7 +68,7 @@ func Run(target string, args []string,
 
 			addregion(reg, i)
 		} else {
-			fnpc, fnerr := bin.FuncToPC(name)
+			fnpc, fnerr := bin.FuncToPC(name, excludeClones)
 
 			if fnerr == nil {
 				logger.Printf("%s: 0x%x\n", name, fnpc)
@@ -76,7 +77,7 @@ func Run(target string, args []string,
 				}, i)
 			}
 
-			inlinings, err := bin.InlinedFuncToPCs(name)
+			inlinings, err := bin.InlinedFuncToPCs(name, excludeClones)
 
 			if len(inlinings) == 0 {
 				logger.Printf("%s not inlined (error: %s)\n", name, err)

--- a/perforator.go
+++ b/perforator.go
@@ -27,7 +27,8 @@ func Run(target string, args []string,
 	events Events,
 	attropts perf.Options,
 	immediate func() MetricsWriter,
-	ignoreMissingRegions bool) (TotalMetrics, error) {
+	ignoreMissingRegions bool,
+	rangeInnerDelimiter string) (TotalMetrics, error) {
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -57,7 +58,7 @@ func Run(target string, args []string,
 
 	for i, name := range regionNames {
 		if strings.Contains(name, "-") {
-			reg, err := ParseRegion(name, bin)
+			reg, err := ParseRegion(name, bin, rangeInnerDelimiter)
 			if err != nil {
 				return TotalMetrics{}, fmt.Errorf("region-parse: %w", err)
 			}

--- a/region.go
+++ b/region.go
@@ -26,8 +26,8 @@ func parseLocation(s string, bin *bininfo.BinFile) (uint64, error) {
 // where 'loc' is a location specified as either a file:line source code
 // location (if the elf binary has DWARF debugging information), or a direct
 // hexadecimal address in the form 0x...
-func ParseRegion(s string, bin *bininfo.BinFile) (*utrace.AddressRegion, error) {
-	parts := strings.Split(s, "-")
+func ParseRegion(s string, bin *bininfo.BinFile, rangeInnerDelimiter string) (*utrace.AddressRegion, error) {
+	parts := strings.Split(s, rangeInnerDelimiter)
 	if len(parts) != 2 {
 		return nil, errors.New("invalid region")
 	}


### PR DESCRIPTION
It closes https://github.com/zyedidia/perforator/issues/10 and https://github.com/zyedidia/perforator/issues/12
Also I add a flag `exclude-clone` to track original functions, not clone versions(`func_name.cold`, for example)